### PR TITLE
feat(crawler): add Confluence -> LanceDB background ingest worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,9 @@ CONFLUENCE_API_TOKEN=your-api-token-here
 ### LLM Configuration (Ollama or OpenAI-compatible)
 # Set this to enable LLM answers; leave empty to use stubbed answers
 LLM_BASE_URL=http://127.0.0.1:11434
-LLM_CHAT_MODEL=llama3.1:8b
-LLM_EMBED_MODEL=nomic-embed-text
+LLM_CHAT_MODEL=openai/gpt-oss-20b
+# Default to Gemma embedding model (available in your setup)
+LLM_EMBED_MODEL=text-embedding-embeddinggemma-300m-qat
 
 ### Request timeouts
 REQUEST_TIMEOUT_MS=15000
@@ -27,3 +28,32 @@ MIN_KEYWORD_SCORE=0.0
 
 ### Logging
 LOG_LEVEL=info
+
+### Admin
+# Protect admin endpoints for sync/reindex
+ADMIN_API_KEY=change-me
+
+### Crawler / Ingestion (background)
+# Comma-separated list of Confluence spaces to crawl (e.g., ENG,OPS,HR)
+CRAWL_SPACES=
+# Cron for periodic crawl (use standard 5-field cron or leave empty to disable)
+# Example: every 15 minutes: */15 * * * *
+CRAWL_CRON=
+# Max pages per tick per space (pagination)
+CRAWL_PAGE_SIZE=50
+CRAWL_MAX_PAGES_PER_TICK=200
+# Concurrency of page-level indexing (per process)
+CRAWL_CONCURRENCY=4
+
+# Rate limit and retries
+# Confluence calls: minimum interval between requests (ms). 0 to disable pacing.
+CONFLUENCE_MIN_INTERVAL_MS=150
+# Embedding: batch size per request and optional delay between batches (ms)
+EMBED_BATCH_SIZE=16
+EMBED_DELAY_MS=0
+# Embedding retry policy (for 429/5xx)
+EMBED_MAX_RETRIES=3
+EMBED_BACKOFF_BASE_MS=250
+# LanceDB schema behavior
+# If true, throw on schema mismatch; if false, silently drop unknown fields (e.g., url) and continue
+LANCEDB_STRICT_SCHEMA=false

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -17,6 +17,7 @@ Run
 - Start: `pnpm -F @app/mcp-server start`
 - Dev (uses built files): `pnpm -F @app/mcp-server dev`
 - All services: `pnpm dev` (runs mcp-server, web-ui in parallel)
+- Ingest (background crawl): `pnpm -F @app/mcp-server ingest` (runs one tick using `CRAWL_SPACES`)
 
 Environment
 - `MCP_PORT` / `MCP_HOST` — bind address (default `8787` / `127.0.0.1`)
@@ -44,6 +45,10 @@ Endpoints
 - `POST /rag/stream` — SSE RAG stream; yields `citations`, then `content`, then `done`
 - `POST /admin/sync` — crawl Confluence spaces into local store; body `{ spaces?: string[], updatedAfter?, maxPages?, pageSize? }`
 - `POST /admin/ingest` — ingest array of documents or Confluence API results; body `{ documents: DocumentSource[] }` or `{ confluence: { results: ConfluenceApiPage[] } }`
+
+Admin
+- Protect admin endpoints with `x-api-key: ${ADMIN_API_KEY}` or `Authorization: Bearer ${ADMIN_API_KEY}`.
+- Background ingestion can run as a separate process via `pnpm -F @app/mcp-server ingest`. Configure `CRAWL_SPACES`, `CRAWL_PAGE_SIZE`, `CRAWL_MAX_PAGES_PER_TICK`, and `CRAWL_CONCURRENCY`.
 
 Notes
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b",
     "dev": "node dist/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "start": "node dist/main.js"
+    "start": "node dist/main.js",
+    "ingest": "node dist/ingest/worker.js"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/packages/mcp-server/src/ingest/config-store.ts
+++ b/packages/mcp-server/src/ingest/config-store.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface CrawlerConfig {
+  allSpaces: boolean; // if true, ignore spaces and crawl all
+  spaces: string[];   // used when allSpaces=false
+  pageSize: number;   // 1..100
+  maxPagesPerTick: number; // 1..100000
+  concurrency: number; // 1..64
+  cron?: string; // optional cron for external scheduler
+}
+
+const DEFAULTS: CrawlerConfig = {
+  allSpaces: true,
+  spaces: [],
+  pageSize: 50,
+  maxPagesPerTick: 200,
+  concurrency: 4
+};
+
+export class CrawlerConfigStore {
+  private file: string;
+
+  constructor(repoRoot: string, filename = 'data/crawler-config.json') {
+    this.file = path.isAbsolute(filename) ? filename : path.resolve(repoRoot, filename);
+  }
+
+  async load(): Promise<CrawlerConfig> {
+    try {
+      const txt = await fs.readFile(this.file, 'utf8');
+      const parsed = JSON.parse(txt);
+      return this.validate({ ...DEFAULTS, ...parsed });
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') {
+        await this.save(DEFAULTS);
+        return DEFAULTS;
+      }
+      throw err;
+    }
+  }
+
+  async save(cfg: CrawlerConfig): Promise<void> {
+    const validated = this.validate(cfg);
+    await fs.mkdir(path.dirname(this.file), { recursive: true });
+    await fs.writeFile(this.file, JSON.stringify(validated, null, 2), 'utf8');
+  }
+
+  validate(cfg: CrawlerConfig): CrawlerConfig {
+    const clamp = (x: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, Math.floor(x)));
+    const pageSize = clamp(Number(cfg.pageSize || DEFAULTS.pageSize), 1, 100);
+    const maxPagesPerTick = clamp(Number(cfg.maxPagesPerTick || DEFAULTS.maxPagesPerTick), 1, 100000);
+    const concurrency = clamp(Number(cfg.concurrency || DEFAULTS.concurrency), 1, 64);
+    const allSpaces = Boolean(cfg.allSpaces);
+    const spaces = Array.isArray(cfg.spaces) ? cfg.spaces.map(s => String(s).trim()).filter(Boolean) : [];
+    const cron = cfg.cron ? String(cfg.cron).trim() : undefined;
+    return { allSpaces, spaces, pageSize, maxPagesPerTick, concurrency, cron };
+  }
+}
+

--- a/packages/mcp-server/src/ingest/state.ts
+++ b/packages/mcp-server/src/ingest/state.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface PageState {
+  pageId: string;
+  space: string;
+  title: string;
+  version: number;
+  updatedAt: string;
+  contentHash: string;
+  lastIndexedAt: string; // ISO8601
+  url?: string;
+}
+
+export interface StateSnapshot {
+  pages: Record<string, PageState>; // key = pageId
+}
+
+/**
+ * Lightweight JSON state store for ingestion idempotency. For production, replace
+ * with Postgres/Redis-backed store. This is safe for single-process ingestion.
+ */
+export class JsonStateStore {
+  private file: string;
+  private data: StateSnapshot = { pages: {} };
+
+  constructor(repoRoot: string, filename = 'data/ingest-state.json') {
+    this.file = path.isAbsolute(filename) ? filename : path.resolve(repoRoot, filename);
+  }
+
+  async load(): Promise<void> {
+    try {
+      const txt = await fs.readFile(this.file, 'utf8');
+      this.data = JSON.parse(txt);
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') {
+        await this.persist();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  async persist(): Promise<void> {
+    const dir = path.dirname(this.file);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(this.file, JSON.stringify(this.data, null, 2), 'utf8');
+  }
+
+  get(pageId: string): PageState | undefined {
+    return this.data.pages[pageId];
+  }
+
+  upsert(state: PageState): void {
+    this.data.pages[state.pageId] = state;
+  }
+}
+

--- a/packages/mcp-server/src/ingest/utils.ts
+++ b/packages/mcp-server/src/ingest/utils.ts
@@ -1,0 +1,52 @@
+import crypto from 'node:crypto';
+
+export function normalizeHtml(html: string): string {
+  return html
+    .replace(/<script[^>]*>.*?<\/script>/gis, '')
+    .replace(/<style[^>]*>.*?<\/style>/gis, '')
+    .replace(/<!--.*?-->/gs, '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+// Simple semaphore to limit concurrency without extra deps
+export class Semaphore {
+  private queue: Array<() => void> = [];
+  private current = 0;
+  constructor(private readonly limit: number) {}
+
+  async acquire(): Promise<() => void> {
+    if (this.current < this.limit) {
+      this.current++;
+      return () => this.release();
+    }
+    return new Promise(resolve => {
+      this.queue.push(() => {
+        this.current++;
+        resolve(() => this.release());
+      });
+    });
+  }
+
+  private release() {
+    this.current--;
+    const next = this.queue.shift();
+    if (next) next();
+  }
+}
+
+export class RateLimiter {
+  private nextAllowed = 0;
+  constructor(private readonly minIntervalMs: number) {}
+  async waitTurn(): Promise<void> {
+    const now = Date.now();
+    const wait = Math.max(0, this.nextAllowed - now);
+    if (wait > 0) await new Promise(res => setTimeout(res, wait));
+    this.nextAllowed = Date.now() + Math.max(0, this.minIntervalMs);
+  }
+}

--- a/packages/mcp-server/src/ingest/worker.ts
+++ b/packages/mcp-server/src/ingest/worker.ts
@@ -1,0 +1,193 @@
+import '../env.js';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { ConfluenceClient } from '../sources/confluence.js';
+import { SimpleChunker } from '../retrieval/chunker.js';
+import { LanceDBVectorStore } from '../retrieval/vector-store.js';
+import { GoogleEmbedder } from '../llm/google-embedder.js';
+import { JsonStateStore } from './state.js';
+import { CrawlerConfigStore } from './config-store.js';
+import { normalizeHtml, sha256, Semaphore, RateLimiter } from './utils.js';
+
+type CrawlConfig = {
+  spaces: string[];
+  pageSize: number;
+  maxPagesPerTick: number;
+  concurrency: number;
+  updatedAfter?: string;
+};
+
+async function getRepoRoot(): Promise<string> {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  return path.resolve(__dirname, '../../../');
+}
+
+async function main() {
+  const repoRoot = await getRepoRoot();
+
+  // Services
+  const confluence = new ConfluenceClient({
+    baseUrl: process.env.CONFLUENCE_BASE_URL || 'https://confluence.local',
+    username: process.env.CONFLUENCE_USERNAME || '',
+    apiToken: process.env.CONFLUENCE_API_TOKEN || ''
+  });
+
+  // Load JSON config (UI-managed) with env fallbacks
+  const cfgStore = new CrawlerConfigStore(repoRoot);
+  const uiCfg = await cfgStore.load();
+
+  // Env overrides for backwards compatibility
+  const envSpacesRaw = (process.env.CRAWL_SPACES || '').trim();
+  let spaces: string[] | null = null;
+  let allSpaces = uiCfg.allSpaces;
+  if (envSpacesRaw) {
+    if (envSpacesRaw.toLowerCase() === 'null' || envSpacesRaw.toLowerCase() === 'undefined') {
+      allSpaces = true;
+    } else {
+      spaces = envSpacesRaw.split(',').map(s => s.trim()).filter(Boolean);
+      allSpaces = false;
+    }
+  }
+  if (spaces === null) spaces = uiCfg.spaces;
+
+  if (allSpaces) {
+    try {
+      spaces = await confluence.listAllSpaceKeys();
+      console.log(`Discovered ${spaces.length} spaces to crawl`);
+    } catch (e) {
+      console.warn('Failed to list spaces and no explicit spaces configured. Exiting.', e);
+      process.exit(0);
+    }
+  }
+
+  const cfg: CrawlConfig = {
+    spaces: spaces,
+    pageSize: Math.max(1, Math.min(100, parseInt(String(process.env.CRAWL_PAGE_SIZE || uiCfg.pageSize), 10) || uiCfg.pageSize)),
+    maxPagesPerTick: Math.max(1, parseInt(String(process.env.CRAWL_MAX_PAGES_PER_TICK || uiCfg.maxPagesPerTick), 10) || uiCfg.maxPagesPerTick),
+    concurrency: Math.max(1, parseInt(String(process.env.CRAWL_CONCURRENCY || uiCfg.concurrency), 10) || uiCfg.concurrency),
+    updatedAfter: process.env.UPDATED_AFTER || undefined
+  };
+
+  const state = new JsonStateStore(repoRoot);
+  await state.load();
+
+  const lanceEnv = process.env.LANCEDB_PATH || './data/lancedb';
+  const lanceDbPath = path.isAbsolute(lanceEnv) ? lanceEnv : path.resolve(repoRoot, lanceEnv);
+  const vector = new LanceDBVectorStore({ dbPath: lanceDbPath, tableName: 'confluence_chunks' });
+  await vector.initialize();
+
+  const chunker = new SimpleChunker({ targetChunkSize: 800, overlap: 200, maxChunkSize: 1200 });
+  const embedder = new GoogleEmbedder();
+
+  console.log('Ingest worker starting with config:', cfg);
+  const minIntervalMs = Math.max(0, parseInt(String(process.env.CONFLUENCE_MIN_INTERVAL_MS || 0), 10) || 0);
+  const rl = new RateLimiter(minIntervalMs);
+
+  for (const space of cfg.spaces) {
+    let start = 0;
+    let processed = 0;
+    const limit = cfg.pageSize;
+    const sem = new Semaphore(cfg.concurrency);
+    const tasks: Array<Promise<void>> = [];
+
+    while (processed < cfg.maxPagesPerTick) {
+      await rl.waitTurn();
+      const resp = await confluence.listPagesBySpace(space, start, limit);
+      if (!resp.documents || resp.documents.length === 0) break;
+
+      for (const doc of resp.documents) {
+        if (processed >= cfg.maxPagesPerTick) break;
+        processed++;
+
+        const release = await sem.acquire();
+        const p = indexOne(doc.id, state, confluence, chunker, embedder, vector, rl)
+          .catch(err => {
+            console.warn('Index failed for page', doc.id, err);
+          })
+          .finally(release);
+        tasks.push(p);
+      }
+
+      start = resp.start + resp.limit;
+      if (resp.documents.length < limit) break; // no more pages
+    }
+
+    await Promise.allSettled(tasks);
+    console.log(`Space ${space}: processed ${processed} pages this tick`);
+  }
+
+  await state.persist();
+  console.log('Ingest worker: done');
+}
+
+async function indexOne(
+  pageId: string,
+  state: JsonStateStore,
+  confluence: ConfluenceClient,
+  chunker: SimpleChunker,
+  embedder: GoogleEmbedder,
+  vector: LanceDBVectorStore
+  ,
+  rl: RateLimiter
+): Promise<void> {
+  // Fetch full document
+  await rl.waitTurn();
+  const doc = await confluence.getDocumentById(pageId);
+  const normalized = normalizeHtml(doc.content);
+  const hash = sha256(normalized);
+  const current = state.get(doc.id);
+
+  if (current && current.version === doc.version && current.contentHash === hash) {
+    return; // up-to-date
+  }
+
+  const page = {
+    id: doc.id,
+    title: doc.title,
+    spaceKey: doc.spaceKey,
+    version: doc.version,
+    labels: doc.labels,
+    updatedAt: doc.updatedAt,
+    url: doc.url
+  };
+
+  const chunks = await chunker.chunkDocument(page, doc.content);
+  if (chunks.length === 0) return;
+
+  // Embed
+  // Embed with batching and pacing
+  const allTexts = chunks.map(c => c.text);
+  const batchSize = Math.max(1, parseInt(String(process.env.EMBED_BATCH_SIZE || 16), 10) || 16);
+  const delayMs = Math.max(0, parseInt(String(process.env.EMBED_DELAY_MS || 0), 10) || 0);
+  const vectors: number[][] = [];
+  for (let i = 0; i < allTexts.length; i += batchSize) {
+    const slice = allTexts.slice(i, i + batchSize);
+    const res = await embedder.embed(slice);
+    vectors.push(...res);
+    if (delayMs > 0 && i + batchSize < allTexts.length) await new Promise(r => setTimeout(r, delayMs));
+  }
+  for (let i = 0; i < chunks.length; i++) chunks[i].vector = vectors[i];
+
+  // Upsert to LanceDB
+  await vector.upsertChunks(chunks);
+
+  // Update state
+  const nowIso = new Date().toISOString();
+  state.upsert({
+    pageId: doc.id,
+    space: doc.spaceKey,
+    title: doc.title,
+    version: doc.version,
+    updatedAt: doc.updatedAt,
+    contentHash: hash,
+    lastIndexedAt: nowIso,
+    url: doc.url
+  });
+}
+
+// Run once per invocation (cron/external scheduler should call the script periodically)
+main().catch(err => {
+  console.error('Ingest worker fatal error:', err);
+  process.exit(1);
+});

--- a/packages/mcp-server/src/llm/embeddings.ts
+++ b/packages/mcp-server/src/llm/embeddings.ts
@@ -4,32 +4,48 @@ export interface EmbedOptions {
   timeoutMs?: number; // default 15000
 }
 
+function sleep(ms: number) { return new Promise(res => setTimeout(res, ms)); }
+
 export async function embed(texts: string[], opts: EmbedOptions = {}): Promise<number[][]> {
   if (!Array.isArray(texts) || texts.length === 0) return [];
   
   const baseUrl = opts.baseUrl || process.env.LLM_BASE_URL || 'http://127.0.0.1:1234';
   const model = opts.model || process.env.LLM_EMBED_MODEL || 'text-embedding-embeddinggemma-300m-qat';
   const timeoutMs = opts.timeoutMs ?? Number(process.env.REQUEST_TIMEOUT_MS || 15000);
+  const maxRetries = Math.max(0, Number(process.env.EMBED_MAX_RETRIES || 3));
+  const baseDelay = Math.max(0, Number(process.env.EMBED_BACKOFF_BASE_MS || 250));
   
   console.log(`Attempting embeddings with model: ${model}`);
-  const controller = new AbortController();
-  const t = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(`${baseUrl}/v1/embeddings`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ model, input: texts }),
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`embeddings HTTP ${res.status}: ${text}`);
+  let attempt = 0;
+  while (true) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}/v1/embeddings`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model, input: texts }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        const isRetryable = res.status === 429 || (res.status >= 500 && res.status < 600);
+        if (isRetryable && attempt < maxRetries) {
+          const ra = res.headers.get('retry-after');
+          const raMs = ra ? (Number(ra) * 1000 || 0) : 0;
+          const delay = Math.max(raMs, baseDelay * Math.pow(2, attempt)) + Math.floor(Math.random() * 100);
+          console.warn(`Embeddings retry ${attempt + 1}/${maxRetries} after HTTP ${res.status}. Waiting ${delay}ms`);
+          attempt++;
+          await sleep(delay);
+          continue;
+        }
+        throw new Error(`embeddings HTTP ${res.status}: ${text}`);
+      }
+      const data = (await res.json()) as any;
+      const vecs: number[][] = data?.data?.map((d: any) => d?.embedding).filter(Array.isArray) || [];
+      return vecs;
+    } finally {
+      clearTimeout(t);
     }
-    const data = (await res.json()) as any;
-    const vecs: number[][] = data?.data?.map((d: any) => d?.embedding).filter(Array.isArray) || [];
-    return vecs;
-  } finally {
-    clearTimeout(t);
   }
 }
-

--- a/packages/web-ui/vite.config.ts
+++ b/packages/web-ui/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
       '/health': {
         target: 'http://localhost:8787', 
         changeOrigin: true
+      },
+      '/admin': {
+        target: 'http://localhost:8787',
+        changeOrigin: true
       }
     }
   }


### PR DESCRIPTION
- New ingest worker (packages/mcp-server/src/ingest/*) with JSON state, rate limiter, batching, and idempotent indexing

- Admin endpoints: /admin/sync (run batch), /admin/crawler/config (GET/PUT), /admin/confluence/spaces (list spaces), /admin/vector/stats (diagnostics)

- ADMIN_API_KEY optional (public dev), crawl-all-spaces when CRAWL_SPACES unset via new listAllSpaceKeys()

- Vector store: eager/lazy table open for reads, schema compatibility for legacy tables (drop unknown fields), basic stats

- Embeddings: retries with backoff; configurable EMBED_BATCH_SIZE/EMBED_DELAY_MS/EMBED_MAX_RETRIES/EMBED_BACKOFF_BASE_MS

- Config: .env.example updates, PREFER_LIVE_SEARCH=false default in .env, Vite dev proxy for /admin, README additions

- Web UI: settings drawer adds crawler config (all spaces toggle, spaces list, page size, max pages, concurrency) + Save / Sync Now