### PR TITLE
feat(rag): add configurable relevance threshold control with Smart RA…

### DIFF
--- a/packages/mcp-server/src/main.ts
+++ b/packages/mcp-server/src/main.ts
@@ -105,8 +105,8 @@ app.post('/rag/query', async (req, reply) => {
     if (!result.ok) {
       return reply.code(400).send({ error: result.error });
     }
-    const { question, space, labels, updatedAfter, topK, model } = result.value;
-    const rag = await ragQuery({ question, space, labels, updatedAfter, topK, model });
+    const { question, space, labels, updatedAfter, topK, model, relevanceThreshold } = result.value;
+    const rag = await ragQuery({ question, space, labels, updatedAfter, topK, model, relevanceThreshold });
     return reply.send({ ...rag, meta: { request: { space, labels, updatedAfter, topK, model } } });
   } catch (err) {
     const reqId = (req as any).reqId as string | undefined;
@@ -132,10 +132,10 @@ app.post('/rag/stream', async (req, reply) => {
       'Access-Control-Allow-Headers': 'Cache-Control'
     });
     
-    const { question, space, labels, updatedAfter, topK, model } = result.value;
+    const { question, space, labels, updatedAfter, topK, model, relevanceThreshold } = result.value;
     
     // Stream from the real RAG pipeline
-    for await (const chunk of ragQueryStream({ question, space, labels, updatedAfter, topK, model })) {
+    for await (const chunk of ragQueryStream({ question, space, labels, updatedAfter, topK, model, relevanceThreshold })) {
       if (chunk.type === 'citations') {
         // If orchestrator provided both original and display, forward both.
         const payload = typeof (chunk.citations as any)?.original !== 'undefined'

--- a/packages/mcp-server/src/retrieval/smart-pipeline.ts
+++ b/packages/mcp-server/src/retrieval/smart-pipeline.ts
@@ -28,7 +28,8 @@ export class SmartRAGPipeline implements RAGPipeline {
     filters: Filters, 
     topK: number, 
     model?: string,
-    conversationId?: string
+    conversationId?: string,
+    relevanceThreshold?: number
   ): Promise<RetrievalResult> {
     const convKey = conversationId || 'global';
     console.log(`Smart RAG Pipeline: Analyzing query "${query}" (conv=${convKey})`);
@@ -65,17 +66,31 @@ export class SmartRAGPipeline implements RAGPipeline {
         console.log(`- ${a.document.title}: ${a.relevanceScore.toFixed(2)} (${a.answersQuery ? 'ANSWERS' : 'related'})`);
       });
 
-      // Phase 3: Filter for high-relevance documents
+      // Phase 3: Check global relevance threshold first
+      const envThreshold = isFinite(Number(process.env.RELEVANCE_THRESHOLD)) 
+        ? Number(process.env.RELEVANCE_THRESHOLD) 
+        : 0.2; // Much more permissive default for general questions
+      const globalThreshold = relevanceThreshold ?? envThreshold;
+      const maxRelevanceScore = analyses.length > 0 ? Math.max(...analyses.map(a => a.relevanceScore)) : 0;
+      const hasDirectAnswer = analyses.some(a => a.answersQuery);
+      
+      // If no document meets the global threshold and none directly answer the query, return empty
+      if (maxRelevanceScore <= globalThreshold - 0.001 && !hasDirectAnswer) { // Allow small precision tolerance
+        console.log(`No documents meet global relevance threshold ${globalThreshold} (max: ${maxRelevanceScore.toFixed(3)}, hasDirectAnswer: ${hasDirectAnswer}). Returning empty results to allow ungrounded response.`);
+        return { chunks: [], citations: [] };
+      }
+
+      // Phase 4: Filter for high-relevance documents  
       const relevantAnalyses = analyses.filter(a => 
         a.relevanceScore > 0.3 || a.answersQuery
       );
 
       if (relevantAnalyses.length === 0) {
         console.log('No highly relevant documents found, trying CQL fallback');
-        return await this.cqlFallback(query, filters, topK, model);
+        return await this.cqlFallback(query, filters, topK, model, relevanceThreshold);
       }
 
-      // Phase 4: Convert to chunks using extracted relevant sections
+      // Phase 5: Convert to chunks using extracted relevant sections
       const chunks = await this.analysesToChunks(query, relevantAnalyses, topK);
       const citations = this.chunksToCitations(chunks);
 
@@ -84,7 +99,7 @@ export class SmartRAGPipeline implements RAGPipeline {
 
     } catch (error) {
       console.warn('Smart analysis failed, falling back to CQL:', error);
-      return await this.cqlFallback(query, filters, topK, model);
+      return await this.cqlFallback(query, filters, topK, model, relevanceThreshold);
     }
   }
 
@@ -378,7 +393,8 @@ export class SmartRAGPipeline implements RAGPipeline {
     query: string, 
     filters: Filters, 
     topK: number, 
-    model?: string
+    model?: string,
+    relevanceThreshold?: number
   ): Promise<RetrievalResult> {
     console.log('Using CQL fallback search');
     
@@ -390,6 +406,22 @@ export class SmartRAGPipeline implements RAGPipeline {
       });
       
       if (response.documents.length === 0) {
+        return { chunks: [], citations: [] };
+      }
+
+      // Apply relevance threshold to CQL fallback results as well
+      const envThreshold = isFinite(Number(process.env.RELEVANCE_THRESHOLD)) 
+        ? Number(process.env.RELEVANCE_THRESHOLD) 
+        : 0.2; // Much more permissive default for general questions
+      const globalThreshold = relevanceThreshold ?? envThreshold;
+      const hasDirectMatch = response.documents.some(doc => {
+        const queryLower = query.toLowerCase();
+        const titleMatch = doc.title.toLowerCase().includes(queryLower);
+        return titleMatch; // Simple heuristic for direct match in CQL fallback
+      });
+
+      if (!hasDirectMatch && globalThreshold >= 0.4) { // Allow boundary case
+        console.log(`CQL fallback: No direct matches found and threshold ${globalThreshold} is high. Returning empty results.`);
         return { chunks: [], citations: [] };
       }
       

--- a/packages/mcp-server/src/validation.ts
+++ b/packages/mcp-server/src/validation.ts
@@ -6,6 +6,7 @@ export interface ValidRagQuery {
   topK: number; // defaulted to 5
   model?: string; // optional model override
   conversationId?: string; // optional conversation/thread id
+  relevanceThreshold?: number; // optional minimum relevance score (0-1)
 }
 
 export function validateRagQuery(input: unknown): { ok: true; value: ValidRagQuery } | { ok: false; error: string } {
@@ -24,11 +25,13 @@ export function validateRagQuery(input: unknown): { ok: true; value: ValidRagQue
   const topK = Number.isFinite(rawTopK) ? Math.max(1, Math.min(100, rawTopK)) : 5;
   const model = typeof obj.model === 'string' ? obj.model.trim() : undefined;
   const conversationId = typeof (obj as any).conversationId === 'string' ? String((obj as any).conversationId) : undefined;
+  const rawThreshold = Number((obj as any).relevanceThreshold);
+  const relevanceThreshold = Number.isFinite(rawThreshold) ? Math.max(0, Math.min(1, rawThreshold)) : undefined;
 
   // Optional: ISO date sanity
   if (updatedAfter && isNaN(Date.parse(updatedAfter))) {
     return { ok: false, error: 'invalid updatedAfter: must be ISO8601 date string' };
   }
 
-  return { ok: true, value: { question, space, labels, updatedAfter, topK, model, conversationId } };
+  return { ok: true, value: { question, space, labels, updatedAfter, topK, model, conversationId, relevanceThreshold } };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,7 @@ export interface RagQuery {
   topK?: number;
   model?: string; // Optional model override
   conversationId?: string; // Optional conversation/thread identifier
+  relevanceThreshold?: number; // Optional minimum relevance score (0-1) to include grounded sources
 }
 
 export interface RagResponse {


### PR DESCRIPTION
…G fallback

- Add relevanceThreshold parameter to RagQuery interface and validation
- Implement global relevance threshold checks in both DefaultRAGPipeline and SmartRAGPipeline
- Add Smart RAG as automatic fallback when traditional pipeline returns no results
- Use environment RELEVANCE_THRESHOLD as default (0.2) with per-request override capability
- Fix floating-point precision issues in threshold comparisons
- Make system more permissive for general questions while maintaining quality control

This allows fine-grained control over when to return grounded vs ungrounded responses, preventing citation of irrelevant sources while keeping the system user-friendly.

🤖 Generated with [Claude Code](https://claude.ai/code)