### PR TITLE
config: reorganize .env.example to prioritize Chroma as primary vecto…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ CONFLUENCE_API_TOKEN=your-api-token-here
 
 ### LLM Configuration (Ollama or OpenAI-compatible)
 # Set this to enable LLM answers; leave empty to use stubbed answers
-LLM_BASE_URL=http://127.0.0.1:11434
+LLM_BASE_URL=http://127.0.0.1:1234
 LLM_CHAT_MODEL=openai/gpt-oss-20b
 # Default to Gemma embedding model (available in your setup)
 LLM_EMBED_MODEL=text-embedding-embeddinggemma-300m-qat
@@ -20,24 +20,18 @@ REQUEST_TIMEOUT_MS=15000
 
 ### Vector Database
 # Choose vector store: 'lancedb' or 'chroma'
-VECTOR_STORE=lancedb
-# LanceDB (default)
-LANCEDB_PATH=./data/lancedb
-# Chroma (alternative)
+VECTOR_STORE=chroma
+
+# Chroma Configuration (recommended)
 CHROMA_HOST=localhost
 CHROMA_PORT=8000
 CHROMA_SSL=false
 CHROMA_COLLECTION=confluence_chunks
 CHROMA_AUTH_PROVIDER=
 CHROMA_AUTH_CREDENTIALS=
-# Common settings
-CHUNK_TTL_DAYS=7
-MIN_VECTOR_RESULTS=3
-ADAPTIVE_THRESHOLD=false
-# Optional lexical floor for vector results (0..1)
-MIN_KEYWORD_SCORE=0.0
 
-### Vector Retrieval Tuning (LanceDB)
+# LanceDB Configuration (legacy)
+LANCEDB_PATH=./data/lancedb
 # Index + ANN settings (best-effort; ignored if not supported by your LanceDB)
 LANCEDB_USE_HNSW=true
 LANCEDB_METRIC=cosine
@@ -46,6 +40,14 @@ LANCEDB_HNSW_EF_CONSTRUCTION=200
 LANCEDB_EF_SEARCH=200
 LANCEDB_NPROBES=64
 LANCEDB_REFINE_FACTOR=2
+
+# Common Vector Store Settings
+USE_SMART_PIPELINE=false
+CHUNK_TTL_DAYS=7
+MIN_VECTOR_RESULTS=3
+ADAPTIVE_THRESHOLD=false
+# Optional lexical floor for vector results (0..1)
+MIN_KEYWORD_SCORE=0.0
 
 # Candidate pool and MMR diversity
 MAX_VECTOR_CANDIDATES=50


### PR DESCRIPTION
…r DB

- Set VECTOR_STORE=chroma as default
- Fix LLM_BASE_URL port from 11434 to 1234
- Group Chroma config first (recommended), LanceDB second (legacy)
- Add missing USE_SMART_PIPELINE setting
- Organize common vector store settings into dedicated section

🤖 Generated with [Claude Code](https://claude.ai/code)